### PR TITLE
Fix incorrect rendering for skeleton

### DIFF
--- a/5568ke/Core/include/SkeletonVisualizer.hpp
+++ b/5568ke/Core/include/SkeletonVisualizer.hpp
@@ -11,7 +11,8 @@ class Node;
 class Model;
 
 /**
- * SkeletonVisualizer - Helper class for visualizing skeletal animations
+ * @brief Helper class for visualizing skeletal animations
+ *
  */
 class SkeletonVisualizer {
 public:
@@ -19,6 +20,7 @@ public:
 	void init();
 	void cleanup();
 
+	bool hasSkeletonData(std::shared_ptr<Model> model) const;
 	void generateSkeletonData(std::shared_ptr<Model> model);
 	void drawDebugLines(std::shared_ptr<Model> model, glm::mat4 const& modelMatrix,
 											std::shared_ptr<Shader> lineShader); // Draw simple debug lines with axes, grid, etc.

--- a/5568ke/Core/src/Application.cpp
+++ b/5568ke/Core/src/Application.cpp
@@ -119,8 +119,8 @@ void Application::setupDefaultScene_()
 	scene_.addLight(glm::vec3(2.0f, 3.0f, 3.0f), glm::vec3(1.0f), 1.0f);
 
 	// Load the character model by default
-	// std::string const path = "assets/models/japanese_classroom/scene.gltf";
-	std::string const path = "assets/models/smo_ina/scene.gltf";
+	std::string const path = "assets/models/japanese_classroom/scene.gltf";
+	// std::string const path = "assets/models/smo_ina/scene.gltf";
 	std::string const name = "ina";
 
 	// Add a character model

--- a/5568ke/Core/src/Renderer.cpp
+++ b/5568ke/Core/src/Renderer.cpp
@@ -136,30 +136,35 @@ void Renderer::drawModels_(Scene const& scene)
 			entity.model->draw(*shaderToUse, scaledModelMatrix);
 		}
 
-		// Draw skeleton if enabled
-		if (showSkeletons) {
-			// Get the line shader
-			auto& lineShader = shaders_["line"];
-			if (!lineShader) {
-				std::cout << "[Renderer ERROR] Line shader is null!" << std::endl;
-				continue;
+		if (auto& skeletonVisualizer = SkeletonVisualizer::getInstance(); // check if the skeleton data exist
+				skeletonVisualizer.hasSkeletonData(entity.model)) {
+
+			// Draw skeleton if enabled
+			if (showSkeletons) {
+
+				// Get the line shader
+				auto& lineShader = shaders_["line"];
+				if (!lineShader) {
+					std::cout << "[Renderer ERROR] Line shader is null!" << std::endl;
+					continue;
+				}
+
+				// Set camera-related uniforms for line shader
+				lineShader->bind();
+				lineShader->sendMat4("view", scene.cam.view);
+				lineShader->sendMat4("proj", scene.cam.proj);
+
+				// Create a scaled transform for the skeleton visualization
+				glm::mat4 scaledModelMatrix = entity.transform;
+				glm::mat4 scaleMatrix = glm::scale(glm::mat4(1.0f), glm::vec3(entity.scale));
+				scaledModelMatrix = scaledModelMatrix * scaleMatrix; // Apply scale
+
+				// Draw debug visualization
+				skeletonVisualizer.drawDebugLines(entity.model, scaledModelMatrix, lineShader);
+
+				// Rebind main shader after drawing lines
+				mainShader_->bind();
 			}
-
-			// Set camera-related uniforms for line shader
-			lineShader->bind();
-			lineShader->sendMat4("view", scene.cam.view);
-			lineShader->sendMat4("proj", scene.cam.proj);
-
-			// Create a scaled transform for the skeleton visualization
-			glm::mat4 scaledModelMatrix = entity.transform;
-			glm::mat4 scaleMatrix = glm::scale(glm::mat4(1.0f), glm::vec3(entity.scale));
-			scaledModelMatrix = scaledModelMatrix * scaleMatrix; // Apply scale
-
-			// Draw debug visualization
-			SkeletonVisualizer::getInstance().drawDebugLines(entity.model, scaledModelMatrix, lineShader);
-
-			// Rebind main shader after drawing lines
-			mainShader_->bind();
 		}
 
 		// Update stats

--- a/5568ke/Core/src/SkeletonVisualizer.cpp
+++ b/5568ke/Core/src/SkeletonVisualizer.cpp
@@ -35,6 +35,31 @@ void SkeletonVisualizer::init()
 	glBindVertexArray(0);
 }
 
+void SkeletonVisualizer::cleanup()
+{
+	skeletonCache.clear();
+
+	if (vao_ != 0) {
+		glDeleteVertexArrays(1, &vao_);
+		vao_ = 0;
+	}
+
+	if (vbo_ != 0) {
+		glDeleteBuffers(1, &vbo_);
+		vbo_ = 0;
+	}
+}
+
+bool SkeletonVisualizer::hasSkeletonData(std::shared_ptr<Model> model) const
+{
+	if (!model)
+		return false;
+
+	// A model has skeleton data if it has animations
+	// Even if it has no joint matrices yet (they might be created when animation plays)
+	return !model->animations.empty();
+}
+
 void SkeletonVisualizer::generateSkeletonData(std::shared_ptr<Model> model)
 {
 	if (!model) {
@@ -140,21 +165,6 @@ void SkeletonVisualizer::processNodePositionsRecursive(std::shared_ptr<Node> nod
 	// Process children recursively
 	for (auto& child : node->children) {
 		processNodePositionsRecursive(child, vertices, colors, nodePosScale);
-	}
-}
-
-void SkeletonVisualizer::cleanup()
-{
-	skeletonCache.clear();
-
-	if (vao_ != 0) {
-		glDeleteVertexArrays(1, &vao_);
-		vao_ = 0;
-	}
-
-	if (vbo_ != 0) {
-		glDeleteBuffers(1, &vbo_);
-		vbo_ = 0;
 	}
 }
 

--- a/5568ke/ImGui/src/ImGuiManager.cpp
+++ b/5568ke/ImGui/src/ImGuiManager.cpp
@@ -187,6 +187,25 @@ void ImGuiManager::drawSceneEntityManager(Scene& scene)
 	ImGui::EndChild();
 	ImGui::Separator();
 
+	// Skeleton visualization controls
+	ImGui::Text("Visualization Options:");
+	auto& renderer = Renderer::getInstance();
+	bool showSkeletons = renderer.showSkeletons;
+	bool showModels = renderer.showModels;
+
+	// Create checkbox for skeleton visibility
+	if (ImGui::Checkbox("Show Skeleton", &showSkeletons)) {
+		std::cout << "[ImGui] Setting skeleton visibility to: " << (showSkeletons ? "ON" : "OFF") << std::endl;
+		renderer.showSkeletons = showSkeletons;
+	}
+
+	// Add checkbox for model visibility
+	if (ImGui::Checkbox("Show Model", &showModels)) {
+		std::cout << "[ImGui] Setting model visibility to: " << (showModels ? "ON" : "OFF") << std::endl;
+		renderer.showModels = showModels;
+	}
+
+	ImGui::Separator();
 	// Entity controls (only show if an entity is selected)
 	if (selectedEntityIndex >= 0 && selectedEntityIndex < static_cast<int>(scene.ents.size())) {
 		Entity& entity = scene.ents[selectedEntityIndex];
@@ -276,9 +295,6 @@ void ImGuiManager::drawSceneEntityManager(Scene& scene)
 //
 void ImGuiManager::drawAnimationControlPanel(Scene& scene)
 {
-	auto& renderer = Renderer::getInstance();
-	bool showSkeletons = renderer.showSkeletons;
-	bool showModels = renderer.showModels;
 	auto& animState = GlobalAnimationState::getInstance();
 
 	ImGui::Begin("Animation Controls");
@@ -453,23 +469,6 @@ void ImGuiManager::drawAnimationControlPanel(Scene& scene)
 		float progress = duration > 0.0f ? (animState.currentTime / duration) : 0.0f;
 		std::string progressStr = std::to_string(static_cast<int>(progress * 100)) + "%";
 		ImGui::ProgressBar(progress, ImVec2(-1, 0), progressStr.c_str());
-	}
-
-	ImGui::Separator();
-
-	// Skeleton visualization controls
-	ImGui::Text("Visualization Options:");
-
-	// Create checkbox for skeleton visibility
-	if (ImGui::Checkbox("Show Skeleton", &showSkeletons)) {
-		std::cout << "[ImGui] Setting skeleton visibility to: " << (showSkeletons ? "ON" : "OFF") << std::endl;
-		renderer.showSkeletons = showSkeletons;
-	}
-
-	// Add checkbox for model visibility
-	if (ImGui::Checkbox("Show Model", &showModels)) {
-		std::cout << "[ImGui] Setting model visibility to: " << (showModels ? "ON" : "OFF") << std::endl;
-		renderer.showModels = showModels;
 	}
 
 	ImGui::End();


### PR DESCRIPTION
The original code incorrectly parsed nodes in models without animation as joints.

This commit adds a new member function to check if the model has animation before deciding whether or not to show the skeleton.