### PR TITLE
Add flag to handle doubleSided attribute

### DIFF
--- a/5568ke/Core/include/Primitive.hpp
+++ b/5568ke/Core/include/Primitive.hpp
@@ -9,4 +9,5 @@ struct Primitive {
 	unsigned int indexOffset; // Offset into the index buffer (in indices, not bytes)
 	unsigned int indexCount;	// Number of indices to draw (usually divisible by 3)
 	Material* material;				// Material to bind when drawing this primitive
+	bool doubleSided = false;
 };

--- a/5568ke/Core/src/Mesh.cpp
+++ b/5568ke/Core/src/Mesh.cpp
@@ -51,7 +51,14 @@ void Mesh::draw(Shader const& shader) const
 	for (auto const& prim : primitives) {
 		if (prim.material)
 			prim.material->bind(shader);
-		glDrawElements(GL_TRIANGLES, prim.indexCount, GL_UNSIGNED_INT, (void*)(prim.indexOffset * sizeof(unsigned int)));
+
+		if (prim.doubleSided)
+			glDisable(GL_CULL_FACE);
+
+		glDrawElements(GL_TRIANGLES, prim.indexCount, GL_UNSIGNED_INT, (void*)(prim.indexOffset * sizeof(unsigned)));
+
+		if (prim.doubleSided)
+			glEnable(GL_CULL_FACE);
 	}
 	glBindVertexArray(0);
 }

--- a/5568ke/ModelLoader/src/GltfLoader.cpp
+++ b/5568ke/ModelLoader/src/GltfLoader.cpp
@@ -252,6 +252,7 @@ void GltfLoader::processMesh_(tinygltf::Model const& model, tinygltf::Mesh const
 		Primitive outPrimitive;
 		outPrimitive.indexOffset = outMesh.indices.size(); // The first index of this primitive inside the big, concatenated index buffer we are building.
 																											 // The renderer will add this offset when it calls 'glDrawElements' later.
+		outPrimitive.doubleSided = (primitive.material >= 0 && model.materials[primitive.material].doubleSided);
 
 		// Get position attribute
 		if (primitive.attributes.find("POSITION") != primitive.attributes.end()) {


### PR DESCRIPTION
Some materials have the attribute doubleSided, for these materials,
face culling is currently turned off directly in 'Mesh::draw'.

Close #2