### PR TITLE
Correct bbox calculation

### DIFF
--- a/5568ke/Core/include/BoundingBox.hpp
+++ b/5568ke/Core/include/BoundingBox.hpp
@@ -2,7 +2,15 @@
 
 #include <glm/glm.hpp>
 
+class Mesh;
+class Model;
+
 struct BoundingBox {
 	glm::vec3 min;
 	glm::vec3 max;
 };
+
+namespace BBoxUtil {
+BoundingBox getMeshBBox(Mesh const& mesh);
+void updateLocalBBox(Model& m);
+} // namespace BBoxUtil

--- a/5568ke/Core/include/Model.hpp
+++ b/5568ke/Core/include/Model.hpp
@@ -19,6 +19,17 @@ public:
 	Model() = default;
 	~Model();
 
+	// Methods for drawing
+	void draw(Shader const& shader, glm::mat4 const& modelMatrix) const;
+
+	// Cleanup resources
+	void cleanup();
+
+	// Animation helper methods
+	void updateMatrices();
+	void initializeDefaultPose();
+
+public:
 	// Core model data
 	std::vector<Mesh> meshes;
 	std::vector<int> meshNodeIndices; // Mesh -> Node mapping
@@ -29,18 +40,6 @@ public:
 	std::string name;
 	std::string filePath;
 
-	// Methods for drawing
-	void draw(Shader const& shader, glm::mat4 const& modelMatrix) const;
-
-	// Cleanup resources
-	void cleanup();
-
-	// Animation helper methods
-	void updateJointMatrices();
-	void updateJointMatricesFromNodes();
-	void initializeDefaultPose();
-
-public:
 	// Animation support
 	std::vector<std::shared_ptr<AnimationClip>> animations;
 	std::vector<std::shared_ptr<Node>> nodes; // node list
@@ -52,8 +51,3 @@ public:
 	std::vector<int> nodeToJointMapping;
 	std::vector<std::vector<std::pair<int, float>>> vertexJoints; // For each vertex: pairs of (jointIndex, weight)
 };
-
-namespace ModelUtil {
-BoundingBox getMeshBBox(Mesh const& mesh);
-void setLocalBBox(Model& m);
-} // namespace ModelUtil

--- a/5568ke/Core/include/Node.hpp
+++ b/5568ke/Core/include/Node.hpp
@@ -7,6 +7,8 @@
 #include <glm/glm.hpp>
 #include <glm/gtx/quaternion.hpp>
 
+class Model;
+
 class Node {
 public:
 	Node(int nodeNum);
@@ -16,8 +18,8 @@ public:
 	glm::mat4 const& getLocalTRSMatrix() const { return localTRSMatrix_; }
 
 	// Operations
-	void calculateLocalTRSMatrix();
-	void calculateNodeMatrix(glm::mat4 const& parentMatrix);
+	void updateLocalTRSMatrix();
+	void updateNodeMatrix(glm::mat4 const& parentMatrix);
 
 	// Hierarchy
 	int nodeNum{-1};
@@ -38,7 +40,8 @@ private:
 namespace NodeUtil {
 
 // Update node tree matrices
-void updateNodeMatricesRecursive(std::shared_ptr<Node> node, glm::mat4 const& parentMatrix);
+void updateNodeTreeMatricesRecursive(std::shared_ptr<Node> node, glm::mat4 const& parentMatrix);
+void updateNodeListLocalTRSMatrix(std::vector<std::shared_ptr<Node>> const& nodes);
+void updateNodeListJointMatrices(Model& model);
 std::shared_ptr<Node> createRoot(int nodeNum);
-
 } // namespace NodeUtil

--- a/5568ke/Core/include/Scene.hpp
+++ b/5568ke/Core/include/Scene.hpp
@@ -24,7 +24,6 @@ struct Light {
 struct Entity {
 	std::shared_ptr<Model> model;
 	glm::mat4 transform;
-	BoundingBox worldBoundingBox;
 	float scale{1.0f};
 
 	// Additional entity properties

--- a/5568ke/Core/src/AnimationClip.cpp
+++ b/5568ke/Core/src/AnimationClip.cpp
@@ -82,11 +82,7 @@ void AnimationClip::setAnimationFrame(std::vector<std::shared_ptr<Node>> const& 
 	}
 
 	// Update all nodes' local matrices
-	for (auto const& node : nodes) {
-		if (node) {
-			node->calculateLocalTRSMatrix();
-		}
-	}
+	NodeUtil::updateNodeListLocalTRSMatrix(nodes);
 
 	// Second pass to update global matrices starting from the root
 	// First find the root node (usually node 0)
@@ -100,7 +96,7 @@ void AnimationClip::setAnimationFrame(std::vector<std::shared_ptr<Node>> const& 
 
 	// If root node was found, update matrices starting from it
 	if (rootNode) {
-		NodeUtil::updateNodeMatricesRecursive(rootNode, glm::mat4(1.0f));
+		NodeUtil::updateNodeTreeMatricesRecursive(rootNode, glm::mat4(1.0f));
 	}
 }
 

--- a/5568ke/Core/src/Application.cpp
+++ b/5568ke/Core/src/Application.cpp
@@ -124,7 +124,7 @@ void Application::setupDefaultScene_()
 
 	// Load the character model by default
 	// std::string const path = "assets/models/japanese_classroom/scene.gltf";
-	std::string const path = "assets/models/smo_ina/scene.gltf";
+	std::string const path = "assets/models/Woman/woman.gltf";
 	std::string const name = "ina";
 
 	// Add a character model
@@ -139,8 +139,7 @@ void Application::setupDefaultScene_()
 			model->initializeDefaultPose();
 
 			// Add to scene
-			registry.addModelToSceneCentered(scene_, model, name, glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f),
-																			 0.0f); // Use calculated scale
+			registry.addModelToSceneCentered(scene_, model, name, glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f));
 
 			// Store entity name in animation state
 			auto& animState = GlobalAnimationState::getInstance();
@@ -270,7 +269,7 @@ void Application::processInput_(float dt)
 								<< std::endl;
 
 			clip->setAnimationFrame(entity->model->nodes, animState.currentTime);
-			entity->model->updateJointMatrices();
+			entity->model->updateMatrices();
 		}
 	}
 }
@@ -307,7 +306,7 @@ void Application::tick_(float dt)
 
 			// Apply animation
 			clip->setAnimationFrame(entity->model->nodes, animState.currentTime);
-			entity->model->updateJointMatrices();
+			entity->model->updateMatrices();
 		}
 	}
 

--- a/5568ke/Core/src/BoundingBox.cpp
+++ b/5568ke/Core/src/BoundingBox.cpp
@@ -1,0 +1,124 @@
+#define GLM_ENABLE_EXPERIMENTAL
+
+#include "BoundingBox.hpp"
+
+#include "Mesh.hpp"
+#include "Model.hpp"
+#include "Node.hpp"
+
+namespace BBoxUtil {
+namespace {
+BoundingBox transformBBox(BoundingBox const& in, glm::mat4 const& M)
+{
+	BoundingBox out;
+	out.min = glm::vec3(std::numeric_limits<float>::max());
+	out.max = glm::vec3(std::numeric_limits<float>::lowest());
+
+	// 8 個 corner
+	for (int c = 0; c < 8; ++c) {
+		glm::vec3 p = {(c & 1 ? in.max.x : in.min.x), (c & 2 ? in.max.y : in.min.y), (c & 4 ? in.max.z : in.min.z)};
+		p = glm::vec3(M * glm::vec4(p, 1.0f));
+		out.min = glm::min(out.min, p);
+		out.max = glm::max(out.max, p);
+	}
+	return out;
+}
+
+BoundingBox getSkinnedMeshBBox(Mesh const& mesh, Model const& model)
+{
+	BoundingBox bbox;
+	bbox.min = glm::vec3(std::numeric_limits<float>::max());
+	bbox.max = glm::vec3(std::numeric_limits<float>::lowest());
+
+	for (auto const& v : mesh.vertices) {
+		glm::vec4 pos(v.position, 1.0f);
+		glm::vec4 skinned(0.0f);
+		float total = 0.0f;
+
+		for (int i = 0; i < 4; ++i) {
+			float w = v.boneWeights[i];
+			int id = v.boneIds[i];
+
+			// do the linear blend skinning
+			if (w > 0.0f && id >= 0 && id < model.jointMatrices.size()) {
+				skinned += w * model.jointMatrices[id] * pos;
+				total += w;
+			}
+		}
+
+		if (total > 0.0f)
+			pos = skinned / total;
+
+		glm::vec3 p = glm::vec3(pos);
+		bbox.min = glm::min(bbox.min, p);
+		bbox.max = glm::max(bbox.max, p);
+	}
+
+	return bbox;
+}
+
+BoundingBox getStaticMeshBox(Model const& model, size_t meshIndex)
+{
+	BoundingBox local = model.boundingBoxes[meshIndex];
+	glm::mat4 nodeM(1.0f);
+
+	if (meshIndex < model.meshNodeIndices.size()) {
+		int nodeIdx = model.meshNodeIndices[meshIndex];
+		if (nodeIdx >= 0 && nodeIdx < model.nodes.size() && model.nodes[nodeIdx])
+			nodeM = model.nodes[nodeIdx]->getNodeMatrix();
+	}
+
+	return transformBBox(local, nodeM);
+}
+} // namespace
+
+BoundingBox getMeshBBox(Mesh const& mesh)
+{
+	BoundingBox bbox;
+	if (mesh.vertices.empty()) {
+		bbox.min = glm::vec3(0.0f);
+		bbox.max = glm::vec3(0.0f);
+		return bbox;
+	}
+
+	bbox.min = glm::vec3(std::numeric_limits<float>::max());
+	bbox.max = glm::vec3(std::numeric_limits<float>::lowest());
+
+	for (auto const& vertex : mesh.vertices) {
+		bbox.min.x = std::min(bbox.min.x, vertex.position.x);
+		bbox.min.y = std::min(bbox.min.y, vertex.position.y);
+		bbox.min.z = std::min(bbox.min.z, vertex.position.z);
+
+		bbox.max.x = std::max(bbox.max.x, vertex.position.x);
+		bbox.max.y = std::max(bbox.max.y, vertex.position.y);
+		bbox.max.z = std::max(bbox.max.z, vertex.position.z);
+	}
+
+	return bbox;
+}
+
+void updateLocalBBox(Model& model)
+{
+	BoundingBox global;
+	global.min = glm::vec3(std::numeric_limits<float>::max());
+	global.max = glm::vec3(std::numeric_limits<float>::lowest());
+
+	// When a model has skinning data, the mesh's node transform is typically baked into the inverse bind matrices.
+	// Applying the node matrix again would result in an oversized bounding box. Detect this case and avoid applying the extra transform.
+	bool hasSkinning = !model.jointMatrices.empty();
+
+	for (size_t i = 0; i < model.meshes.size(); ++i) {
+		BoundingBox local;
+
+		if (hasSkinning)
+			local = getSkinnedMeshBBox(model.meshes[i], model);
+		else
+			local = getStaticMeshBox(model, i);
+
+		global.min = glm::min(global.min, local.min);
+		global.max = glm::max(global.max, local.max);
+	}
+
+	model.localSpaceBBox = global;
+}
+} // namespace BBoxUtil

--- a/5568ke/Core/src/Model.cpp
+++ b/5568ke/Core/src/Model.cpp
@@ -66,129 +66,22 @@ void Model::cleanup()
 }
 
 // Support animation functionality
-void Model::updateJointMatrices()
+void Model::updateMatrices()
 {
 	if (!rootNode) {
 		return;
 	}
 
-	std::cout << "[Model] Updating joint matrices" << std::endl;
-
-	// First update all local matrices
-	for (auto& node : nodes) {
-		if (node) {
-			node->calculateLocalTRSMatrix();
-		}
-	}
-
-	// Now update all global matrices in a hierarchical way
-	NodeUtil::updateNodeMatricesRecursive(rootNode, glm::mat4(1.0f));
-
-	// Finally, update the joint matrices
-	updateJointMatricesFromNodes();
-}
-
-void Model::updateJointMatricesFromNodes()
-{
-	// Update joint matrices if this node is a joint
-	for (auto const& node : nodes) {
-		if (!node)
-			continue;
-
-		int nodeIndex = node->nodeNum;
-		if (nodeIndex < nodeToJointMapping.size()) {
-			int jointIndex = nodeToJointMapping[nodeIndex];
-			if (jointIndex >= 0 && jointIndex < jointMatrices.size() && jointIndex < inverseBindMatrices.size()) {
-				jointMatrices[jointIndex] = node->getNodeMatrix() * inverseBindMatrices[jointIndex];
-			}
-		}
-	}
+	std::cout << "[Model] Updating matrices" << std::endl;
+	NodeUtil::updateNodeListLocalTRSMatrix(nodes);
+	NodeUtil::updateNodeTreeMatricesRecursive(rootNode, glm::mat4(1.0f));
+	NodeUtil::updateNodeListJointMatrices(*this);
+	BBoxUtil::updateLocalBBox(*this);
 }
 
 void Model::initializeDefaultPose()
 {
-	// Make sure all nodes have proper local matrices calculated
-	for (auto& node : nodes) {
-		if (node) {
-			node->calculateLocalTRSMatrix();
-		}
-	}
-
-	// Update global matrices starting from the root
-	if (rootNode) {
-		NodeUtil::updateNodeMatricesRecursive(rootNode, glm::mat4(1.0f));
-	}
-
-	// Update joint matrices based on the default pose
-	updateJointMatricesFromNodes();
+	updateMatrices();
 
 	std::cout << "[Model] Initialized default pose with " << jointMatrices.size() << " joint matrices" << std::endl;
 }
-
-namespace ModelUtil {
-namespace {
-BoundingBox transformBBox(BoundingBox const& in, glm::mat4 const& M)
-{
-	BoundingBox out;
-	out.min = glm::vec3(std::numeric_limits<float>::max());
-	out.max = glm::vec3(std::numeric_limits<float>::lowest());
-
-	// 8 個 corner
-	for (int c = 0; c < 8; ++c) {
-		glm::vec3 p = {(c & 1 ? in.max.x : in.min.x), (c & 2 ? in.max.y : in.min.y), (c & 4 ? in.max.z : in.min.z)};
-		p = glm::vec3(M * glm::vec4(p, 1.0f));
-		out.min = glm::min(out.min, p);
-		out.max = glm::max(out.max, p);
-	}
-	return out;
-}
-} // namespace
-
-BoundingBox getMeshBBox(Mesh const& mesh)
-{
-	BoundingBox bbox;
-	if (mesh.vertices.empty()) {
-		bbox.min = glm::vec3(0.0f);
-		bbox.max = glm::vec3(0.0f);
-		return bbox;
-	}
-
-	bbox.min = glm::vec3(std::numeric_limits<float>::max());
-	bbox.max = glm::vec3(std::numeric_limits<float>::lowest());
-
-	for (auto const& vertex : mesh.vertices) {
-		bbox.min.x = std::min(bbox.min.x, vertex.position.x);
-		bbox.min.y = std::min(bbox.min.y, vertex.position.y);
-		bbox.min.z = std::min(bbox.min.z, vertex.position.z);
-
-		bbox.max.x = std::max(bbox.max.x, vertex.position.x);
-		bbox.max.y = std::max(bbox.max.y, vertex.position.y);
-		bbox.max.z = std::max(bbox.max.z, vertex.position.z);
-	}
-
-	return bbox;
-}
-
-void setLocalBBox(Model& m)
-{
-	BoundingBox global;
-	global.min = glm::vec3(std::numeric_limits<float>::max());
-	global.max = glm::vec3(std::numeric_limits<float>::lowest());
-
-	for (size_t i = 0; i < m.meshes.size(); ++i) {
-		BoundingBox local = m.boundingBoxes[i];
-		glm::mat4 nodeM(1.0f);
-
-		if (i < m.meshNodeIndices.size()) {
-			int nodeIdx = m.meshNodeIndices[i];
-			if (nodeIdx >= 0 && nodeIdx < m.nodes.size() && m.nodes[nodeIdx])
-				nodeM = m.nodes[nodeIdx]->getNodeMatrix();
-		}
-		BoundingBox world = transformBBox(local, nodeM);
-
-		global.min = glm::min(global.min, world.min);
-		global.max = glm::max(global.max, world.max);
-	}
-	m.localSpaceBBox = global;
-}
-} // namespace ModelUtil

--- a/5568ke/ImGui/include/ImGuiManager.hpp
+++ b/5568ke/ImGui/include/ImGuiManager.hpp
@@ -51,5 +51,5 @@ private:
 	void refreshFileList();
 	void loadSelectedModel(Scene& scene);
 	void drawTransformEditor(Entity& entity);
-	void drawNodeHierarchy(std::shared_ptr<Node> node, int depth);
+	void drawNodeTree(std::shared_ptr<Node> node, int depth);
 };

--- a/5568ke/ImGui/src/ImGuiManager.cpp
+++ b/5568ke/ImGui/src/ImGuiManager.cpp
@@ -234,7 +234,7 @@ void ImGuiManager::drawSceneEntityManager(Scene& scene)
 			ImGui::Text("Root node ID: %d, Name: %s", rootNode->nodeNum, rootNode->nodeName.empty() ? "<unnamed>" : rootNode->nodeName.c_str());
 
 			// Show full hierarchy starting at root
-			drawNodeHierarchy(rootNode, 0);
+			drawNodeTree(rootNode, 0);
 
 			// If root node doesn't have all nodes as descendants,
 			// find potential other top-level nodes
@@ -264,7 +264,7 @@ void ImGuiManager::drawSceneEntityManager(Scene& scene)
 					}
 
 					// Show each disconnected node
-					drawNodeHierarchy(entity.model->nodes[i], 0);
+					drawNodeTree(entity.model->nodes[i], 0);
 				}
 			}
 		}
@@ -349,7 +349,7 @@ void ImGuiManager::drawAnimationControlPanel(Scene& scene)
 				// Reset animation visually
 				if (entity->model->animations.size() > selectedClipIndex) {
 					entity->model->animations[selectedClipIndex]->setAnimationFrame(entity->model->nodes, 0.0f);
-					entity->model->updateJointMatrices();
+					entity->model->updateMatrices();
 				}
 			}
 			if (isSelected) {
@@ -389,7 +389,7 @@ void ImGuiManager::drawAnimationControlPanel(Scene& scene)
 			// Update animation frame if this is the current entity
 			if (entity->model->animations.size() > selectedClipIndex) {
 				entity->model->animations[selectedClipIndex]->setAnimationFrame(entity->model->nodes, currentTime);
-				entity->model->updateJointMatrices();
+				entity->model->updateMatrices();
 			}
 		}
 	}
@@ -406,7 +406,7 @@ void ImGuiManager::drawAnimationControlPanel(Scene& scene)
 		// Apply initial frame for visual feedback
 		if (entity->model->animations.size() > selectedClipIndex) {
 			entity->model->animations[selectedClipIndex]->setAnimationFrame(entity->model->nodes, 0.0f);
-			entity->model->updateJointMatrices();
+			entity->model->updateMatrices();
 		}
 	}
 	ImGui::SameLine();
@@ -438,7 +438,7 @@ void ImGuiManager::drawAnimationControlPanel(Scene& scene)
 		// Reset visually
 		if (entity->model->animations.size() > selectedClipIndex) {
 			entity->model->animations[selectedClipIndex]->setAnimationFrame(entity->model->nodes, 0.0f);
-			entity->model->updateJointMatrices();
+			entity->model->updateMatrices();
 		}
 	}
 
@@ -458,7 +458,7 @@ void ImGuiManager::drawAnimationControlPanel(Scene& scene)
 }
 
 // Implement the node hierarchy display function
-void ImGuiManager::drawNodeHierarchy(std::shared_ptr<Node> node, int depth)
+void ImGuiManager::drawNodeTree(std::shared_ptr<Node> node, int depth)
 {
 	if (!node) {
 		return;
@@ -518,7 +518,7 @@ void ImGuiManager::drawNodeHierarchy(std::shared_ptr<Node> node, int depth)
 
 		// Process all children
 		for (auto const& child : node->children) {
-			drawNodeHierarchy(child, depth + 1);
+			drawNodeTree(child, depth + 1);
 		}
 
 		ImGui::Unindent();

--- a/5568ke/ModelLoader/src/GltfLoader.cpp
+++ b/5568ke/ModelLoader/src/GltfLoader.cpp
@@ -82,7 +82,7 @@ std::shared_ptr<Model> GltfLoader::loadGltf_(std::string const& path, MaterialTy
 		outMesh.setup();
 
 		// Calculate bounding box
-		BoundingBox bbox = ModelUtil::getMeshBBox(outMesh);
+		BoundingBox bbox = BBoxUtil::getMeshBBox(outMesh);
 		model->boundingBoxes.push_back(bbox);
 
 		// Add mesh to model
@@ -115,13 +115,13 @@ std::shared_ptr<Model> GltfLoader::loadGltf_(std::string const& path, MaterialTy
 
 	if (model->rootNode) {
 		// Calculate all node matrices starting from the root
-		NodeUtil::updateNodeMatricesRecursive(model->rootNode, glm::mat4(1.0f));
+		NodeUtil::updateNodeTreeMatricesRecursive(model->rootNode, glm::mat4(1.0f));
 		std::cout << "[GltfLoader] Node matrices calculated for static transforms" << std::endl;
 	}
 
 	// Calculate global bounding box and store on the model
 	if (!model->boundingBoxes.empty()) {
-		ModelUtil::setLocalBBox(*model);
+		BBoxUtil::updateLocalBBox(*model);
 
 		// Print global bounding box info
 		std::cout << "[GltfLoader INFO] Model global bounding box: min(" << model->localSpaceBBox.min.x << ", " << model->localSpaceBBox.min.y << ", "
@@ -619,8 +619,8 @@ void GltfLoader::processNodeTreeRecursive_(std::shared_ptr<Model> model, tinyglt
 
 	try {
 		// Calculate matrices
-		currentNode->calculateLocalTRSMatrix();
-		currentNode->calculateNodeMatrix(parentMatrix);
+		currentNode->updateLocalTRSMatrix();
+		currentNode->updateNodeMatrix(parentMatrix);
 
 		// Process child nodes
 		std::cout << "[GltfLoader INFO] Node " << nodeIndex << " has " << node.children.size() << " children" << std::endl;

--- a/5568ke/Renderer/include/SkeletonVisualizer.hpp
+++ b/5568ke/Renderer/include/SkeletonVisualizer.hpp
@@ -30,7 +30,7 @@ private:
 	~SkeletonVisualizer() = default;
 
 	// Helper methods for visualization
-	void processNodePositionsRecursive(std::shared_ptr<Node> node, std::vector<glm::vec3>& vertices, std::vector<glm::vec3>& colors, float nodePosScale);
+	void processNodeTreePositionsRecursive(std::shared_ptr<Node> node, std::vector<glm::vec3>& vertices, std::vector<glm::vec3>& colors, float nodePosScale);
 	void addDotJoint(glm::vec3 const& position, float radius, glm::vec3 const& color, std::vector<glm::vec3>& vertices, std::vector<glm::vec3>& colors);
 
 	// OpenGL resources

--- a/5568ke/Renderer/src/Renderer.cpp
+++ b/5568ke/Renderer/src/Renderer.cpp
@@ -144,15 +144,15 @@ void Renderer::drawModels_(Scene const& scene)
 			shaderToUse->bind();
 
 			// Create a modified model matrix that includes the entity's scale
-			glm::mat4 scaledModelMatrix = entity.transform;
+			glm::mat4 modelMatrix = entity.transform;
 
 			// Apply scaling to the model matrix
 			// We create a separate scaling matrix and multiply it with the entity's transform
 			glm::mat4 scaleMatrix = glm::scale(glm::mat4(1.0f), glm::vec3(entity.scale));
-			scaledModelMatrix = scaledModelMatrix * scaleMatrix; // Apply scale
+			modelMatrix = modelMatrix * scaleMatrix; // Apply scale
 
 			// Draw the model with the scaled model matrix
-			entity.model->draw(*shaderToUse, scaledModelMatrix);
+			entity.model->draw(*shaderToUse, modelMatrix);
 		}
 
 		if (auto& skeletonVisualizer = SkeletonVisualizer::getInstance(); // check if the skeleton data exist
@@ -174,12 +174,12 @@ void Renderer::drawModels_(Scene const& scene)
 				lineShader->sendMat4("proj", scene.cam.proj);
 
 				// Create a scaled transform for the skeleton visualization
-				glm::mat4 scaledModelMatrix = entity.transform;
+				glm::mat4 modelMatrix = entity.transform;
 				glm::mat4 scaleMatrix = glm::scale(glm::mat4(1.0f), glm::vec3(entity.scale));
-				scaledModelMatrix = scaledModelMatrix * scaleMatrix; // Apply scale
+				modelMatrix = modelMatrix * scaleMatrix; // Apply scale
 
 				// Draw debug visualization
-				skeletonVisualizer.drawDebugLines(entity.model, scaledModelMatrix, lineShader);
+				skeletonVisualizer.drawDebugLines(entity.model, modelMatrix, lineShader);
 
 				// Rebind main shader after drawing lines
 				mainShader_->bind();

--- a/5568ke/Renderer/src/SkeletonVisualizer.cpp
+++ b/5568ke/Renderer/src/SkeletonVisualizer.cpp
@@ -85,7 +85,7 @@ void SkeletonVisualizer::generateSkeletonData(std::shared_ptr<Model> model)
 
 	// Process the node hierarchy recursively starting from the root
 	float nodePosScale = 0.005f;
-	processNodePositionsRecursive(model->rootNode, skeletonData.vertices, skeletonData.colors, nodePosScale);
+	processNodeTreePositionsRecursive(model->rootNode, skeletonData.vertices, skeletonData.colors, nodePosScale);
 
 	std::cout << "[SkeletonVisualizer] Generated " << skeletonData.vertices.size() << " vertices for skeleton lines" << std::endl;
 
@@ -93,8 +93,8 @@ void SkeletonVisualizer::generateSkeletonData(std::shared_ptr<Model> model)
 	skeletonCache[model] = skeletonData;
 }
 
-void SkeletonVisualizer::processNodePositionsRecursive(std::shared_ptr<Node> node, std::vector<glm::vec3>& vertices, std::vector<glm::vec3>& colors,
-																											 float nodePosScale)
+void SkeletonVisualizer::processNodeTreePositionsRecursive(std::shared_ptr<Node> node, std::vector<glm::vec3>& vertices, std::vector<glm::vec3>& colors,
+																													 float nodePosScale)
 {
 	if (!node)
 		return;
@@ -107,7 +107,7 @@ void SkeletonVisualizer::processNodePositionsRecursive(std::shared_ptr<Node> nod
 	if (glm::length(nodePos) < 0.001f) {
 		// Process children anyway
 		for (auto& child : node->children) {
-			processNodePositionsRecursive(child, vertices, colors, nodePosScale);
+			processNodeTreePositionsRecursive(child, vertices, colors, nodePosScale);
 		}
 		return;
 	}
@@ -164,7 +164,7 @@ void SkeletonVisualizer::processNodePositionsRecursive(std::shared_ptr<Node> nod
 
 	// Process children recursively
 	for (auto& child : node->children) {
-		processNodePositionsRecursive(child, vertices, colors, nodePosScale);
+		processNodeTreePositionsRecursive(child, vertices, colors, nodePosScale);
 	}
 }
 
@@ -188,7 +188,7 @@ void SkeletonVisualizer::drawDebugLines(std::shared_ptr<Model> model, glm::mat4 
 	if (model->rootNode) {
 		// Use the same scale factor for skeleton as for the model
 		float nodePosScale = 1.0f; // This will be applied with the model matrix
-		processNodePositionsRecursive(model->rootNode, vertices, colors, nodePosScale);
+		processNodeTreePositionsRecursive(model->rootNode, vertices, colors, nodePosScale);
 	}
 
 	// Skip if no vertices


### PR DESCRIPTION
The original code mixed the name of the model matrix in MVP transformation and the matrix of the class 'Model'. This caused the
confusion when doing the transformation. Thus this commit clarify the name of these matrix and function at first.

The main problem of the bbox now is that Skinned models were computing their bounding boxes with the mesh's node transform applied in CPU code.

However, the vertex shader already multiplies each vertex by 'jointMatrices', which include the node transformations, before applying the model matrix.

Because the CPU code also multiplied each mesh's local bounding box by the node matrix, the transformation was effectively applied twice, producing oversized and offset bounding boxes.

This commit add several utility for bbox, it would detected that if the model contained animation, then called the corresponding bbox calculation.